### PR TITLE
Fix importing in __init__.py

### DIFF
--- a/minipdf/__init__.py
+++ b/minipdf/__init__.py
@@ -1,3 +1,3 @@
-from minipdf import *
+from .minipdf import *
 
 __version__ = '0.1'


### PR DESCRIPTION
importing "from minipdf" in __init__.py fails when minipdf is installed as package. Prefixing with a "." to indicate we want to import from a "submodule" in the current directory fixes this.